### PR TITLE
use isProjectCanceled to check for canceled project

### DIFF
--- a/contracts/LiquidPledging.sol
+++ b/contracts/LiquidPledging.sol
@@ -180,7 +180,7 @@ function donate(uint64 idGiver, uint64 idReceiver) payable {
         require(n.paymentState == PaymentState.Paying);
 
         // Check the project is not canceled in the while.
-        require(getOldestPledgeNotCanceled(idPledge) == idPledge);
+        require(!isProjectCanceled(n.owner));
 
         uint64 idNewPledge = findOrCreatePledge(
             n.owner,


### PR DESCRIPTION
this is more clear the using `getOldestPledgeNotCanceled` and checking that the value === the current pledgeId