### PR TITLE
remove useless methods

### DIFF
--- a/contracts/LiquidPledging.sol
+++ b/contracts/LiquidPledging.sol
@@ -265,24 +265,6 @@ function donate(uint64 idGiver, uint64 idReceiver) payable {
         }
     }
 
-    function mConfirmPayment(uint[] pledgesAmounts) {
-        for (uint i = 0; i < pledgesAmounts.length; i++ ) {
-            uint64 idPledge = uint64( pledgesAmounts[i] & (D64-1) );
-            uint amount = pledgesAmounts[i] / D64;
-
-            confirmPayment(idPledge, amount);
-        }
-    }
-
-    function mCancelPayment(uint[] pledgesAmounts) {
-        for (uint i = 0; i < pledgesAmounts.length; i++ ) {
-            uint64 idPledge = uint64( pledgesAmounts[i] & (D64-1) );
-            uint amount = pledgesAmounts[i] / D64;
-
-            cancelPayment(idPledge, amount);
-        }
-    }
-
     function mNormalizePledge(uint[] pledges) returns(uint64) {
         for (uint i = 0; i < pledges.length; i++ ) {
             uint64 idPledge = uint64( pledges[i] & (D64-1) );


### PR DESCRIPTION
`mConfirmPayment` and `mCancelPayment` are only callable by the vault. However, the
vault never calls them and has a much simpler way to deal with
confirming and canceling multiple payments using only the `paymentId`, which
doesn't require encoding the pledge id & amount into a single value for
each pledge.

thus `mConfirmPayment` and `mCancelPayment` can never be called.